### PR TITLE
Small fixes

### DIFF
--- a/src/lib/dao.js
+++ b/src/lib/dao.js
@@ -1,5 +1,5 @@
 const mysql = require('./mysqlWrapper')
-const { sqlConstants } = require('../util/sqlConstants')
+const sqlConstants = require('../util/sqlConstants')
 
 class DAO {
 


### PR DESCRIPTION
The `exports` object in the sqlConstants file doesn't have a member called sqlConstants, it rather has the ASC and DESC themselves.  